### PR TITLE
materials: playerclip brush should not allow building inside

### DIFF
--- a/scripts/common.shader
+++ b/scripts/common.shader
@@ -280,6 +280,7 @@ textures/common/playerclip
 	qer_editorImage textures/common_src/playerclip_p
 	qer_trans .4
 
+	surfaceparm nobuild
 	surfaceparm nodraw
 	surfaceparm nonsolid
 	surfaceparm playerclip


### PR DESCRIPTION
We may also want to patch the game to disallow building inside playerclip brushes, as old maps will not be rebuilt.