### PR TITLE
rewrite the `common` and `colors` shaders in a better way

### DIFF
--- a/.urcheon/action/build.txt
+++ b/.urcheon/action/build.txt
@@ -1,7 +1,6 @@
 convert_jpg textures/radiant/notex.png
 convert_jpg textures/radiant/shadernotex.png
 copy textures/common_src/black_d.tga
-copy textures/common_src/transparent_d.tga
 copy textures/shared_colors_src/azure_d.tga
 copy textures/shared_colors_src/black_d.tga
 copy textures/shared_colors_src/blue_d.tga
@@ -14,6 +13,7 @@ copy textures/shared_colors_src/orange_d.tga
 copy textures/shared_colors_src/red_d.tga
 copy textures/shared_colors_src/rose_d.tga
 copy textures/shared_colors_src/spring_d.tga
+copy textures/shared_colors_src/transparent_d.tga
 copy textures/shared_colors_src/violet_d.tga
 copy textures/shared_colors_src/white_d.tga
 copy textures/shared_colors_src/yellow_d.tga

--- a/scripts/common.shader
+++ b/scripts/common.shader
@@ -198,8 +198,8 @@ textures/common/mirror
 	portal
 
 	{
-		map textures/shared_colors_src/transparent_d
-		blendfunc GL_ONE GL_ONE_MINUS_SRC_ALPHA
+		map $black
+		blendfunc GL_ZERO GL_ONE
 		depthWrite
 	}
 }
@@ -290,8 +290,8 @@ textures/common/portal
 	portal
 
 	{
-		map textures/shared_colors_src/transparent_d
-		blendfunc GL_ONE GL_ONE_MINUS_SRC_ALPHA
+		map $black
+		blendfunc GL_ZERO GL_ONE
 		depthWrite
 	}
 }

--- a/scripts/common.shader
+++ b/scripts/common.shader
@@ -40,7 +40,7 @@ textures/common/black
 	surfaceparm nomarks
 
 	{
-		diffuseMap textures/shared_colors_src/black_d
+		map textures/shared_colors_src/black_d
 	}
 }
 

--- a/scripts/common.shader
+++ b/scripts/common.shader
@@ -40,7 +40,7 @@ textures/common/black
 	surfaceparm nomarks
 
 	{
-		map textures/shared_colors_src/black_d
+		map $black
 	}
 }
 
@@ -144,11 +144,6 @@ textures/common/invisible
 
 	surfaceparm nolightmap
 	surfaceparm trans
-
-	{
-		map textures/shared_colors_src/transparent_d
-		alphaFunc GE128
-	}
 }
 
 // An invsible surface that players can climb on.

--- a/scripts/shared_colors.shader
+++ b/scripts/shared_colors.shader
@@ -31,7 +31,8 @@ textures/shared_colors/gray
 	surfaceparm nomarks
 
 	{
-		map textures/shared_colors_src/gray_d
+		map $white
+		rgbgen const (.5 .5 .5)
 	}
 }
 
@@ -44,7 +45,8 @@ textures/shared_colors/gray_nonsolid
 	surfaceparm nonsolid
 
 	{
-		map textures/shared_colors_src/gray_d
+		map $white
+		rgbgen const (.5 .5 .5)
 	}
 }
 
@@ -81,7 +83,8 @@ textures/shared_colors/red
 	surfaceparm nomarks
 
 	{
-		map $red
+		map $white
+		rgbgen const (1 0 0)
 	}
 }
 
@@ -94,7 +97,8 @@ textures/shared_colors/red_nonsolid
 	surfaceparm nonsolid
 
 	{
-		map $red
+		map $white
+		rgbgen const (1 0 0)
 	}
 }
 
@@ -106,7 +110,8 @@ textures/shared_colors/orange
 	surfaceparm nomarks
 
 	{
-		map textures/shared_colors_src/orange_d
+		map $white
+		rgbgen const (1 .5 0)
 	}
 }
 
@@ -119,7 +124,8 @@ textures/shared_colors/orange_nonsolid
 	surfaceparm nonsolid
 
 	{
-		map textures/shared_colors_src/orange_d
+		map $white
+		rgbgen const (1 .5 0)
 	}
 }
 
@@ -131,7 +137,8 @@ textures/shared_colors/yellow
 	surfaceparm nomarks
 
 	{
-		map textures/shared_colors_src/yellow_d
+		map $white
+		rgbgen const (1 1 0)
 	}
 }
 
@@ -144,7 +151,8 @@ textures/shared_colors/yellow_nonsolid
 	surfaceparm nonsolid
 
 	{
-		map textures/shared_colors_src/yellow_d
+		map $white
+		rgbgen const (1 1 0)
 	}
 }
 
@@ -156,7 +164,8 @@ textures/shared_colors/chartreuse
 	surfaceparm nomarks
 
 	{
-		map textures/shared_colors_src/chartreuse_d
+		map $white
+		rgbgen const (.5 1 0)
 	}
 }
 
@@ -169,7 +178,8 @@ textures/shared_colors/chartreuse_nonsolid
 	surfaceparm nonsolid
 
 	{
-		map textures/shared_colors_src/chartreuse_d
+		map $white
+		rgbgen const (.5 1 0)
 	}
 }
 
@@ -181,7 +191,8 @@ textures/shared_colors/green
 	surfaceparm nomarks
 
 	{
-		map $green
+		map $white
+		rgbgen const (0 1 0)
 	}
 }
 
@@ -194,7 +205,8 @@ textures/shared_colors/green_nonsolid
 	surfaceparm nonsolid
 
 	{
-		map $green
+		map $white
+		rgbgen const (0 1 0)
 	}
 }
 
@@ -206,7 +218,8 @@ textures/shared_colors/spring
 	surfaceparm nomarks
 
 	{
-		map textures/shared_colors_src/spring_d
+		map $white
+		rgbgen const (0 1 .5)
 	}
 }
 
@@ -219,7 +232,8 @@ textures/shared_colors/spring_nonsolid
 	surfaceparm nonsolid
 
 	{
-		map textures/shared_colors_src/spring_d
+		map $white
+		rgbgen const (0 1 .5)
 	}
 }
 
@@ -231,7 +245,8 @@ textures/shared_colors/cyan
 	surfaceparm nomarks
 
 	{
-		map textures/shared_colors_src/cyan_d
+		map $white
+		rgbgen const (0 1 1)
 	}
 }
 
@@ -244,7 +259,8 @@ textures/shared_colors/cyan_nonsolid
 	surfaceparm nonsolid
 
 	{
-		map textures/shared_colors_src/cyan_d
+		map $white
+		rgbgen const (0 1 1)
 	}
 }
 
@@ -256,7 +272,8 @@ textures/shared_colors/azure
 	surfaceparm nomarks
 
 	{
-		map textures/shared_colors_src/azure_d
+		map $white
+		rgbgen const (0 .5 1)
 	}
 }
 
@@ -269,7 +286,8 @@ textures/shared_colors/azure_nonsolid
 	surfaceparm nonsolid
 
 	{
-		map textures/shared_colors_src/azure_d
+		map $white
+		rgbgen const (0 .5 1)
 	}
 }
 
@@ -281,7 +299,8 @@ textures/shared_colors/blue
 	surfaceparm nomarks
 
 	{
-		map $blue
+		map $white
+		rgbgen const (0 0 1)
 	}
 }
 
@@ -294,7 +313,8 @@ textures/shared_colors/blue_nonsolid
 	surfaceparm nonsolid
 
 	{
-		map $blue
+		map $white
+		rgbgen const (0 0 1)
 	}
 }
 
@@ -306,7 +326,8 @@ textures/shared_colors/violet
 	surfaceparm nomarks
 
 	{
-		map textures/shared_colors_src/violet_d
+		map $white
+		rgbgen const (.5 0 1)
 	}
 }
 
@@ -319,7 +340,8 @@ textures/shared_colors/violet_nonsolid
 	surfaceparm nonsolid
 
 	{
-		map textures/shared_colors_src/violet_d
+		map $white
+		rgbgen const (.5 0 1)
 	}
 }
 
@@ -331,7 +353,8 @@ textures/shared_colors/magenta
 	surfaceparm nomarks
 
 	{
-		map textures/shared_colors_src/magenta_d
+		map $white
+		rgbgen const (1 0 1)
 	}
 }
 
@@ -344,7 +367,8 @@ textures/shared_colors/magenta_nonsolid
 	surfaceparm nonsolid
 
 	{
-		map textures/shared_colors_src/magenta_d
+		map $white
+		rgbgen const (1 0 1)
 	}
 }
 
@@ -356,7 +380,8 @@ textures/shared_colors/rose
 	surfaceparm nomarks
 
 	{
-		map textures/shared_colors_src/rose_d
+		map $white
+		rgbgen const (1 0 .5)
 	}
 }
 
@@ -369,7 +394,8 @@ textures/shared_colors/rose_nonsolid
 	surfaceparm nonsolid
 
 	{
-		map textures/shared_colors_src/rose_d
+		map $white
+		rgbgen const (1 0 .5)
 	}
 }
 

--- a/scripts/shared_colors.shader
+++ b/scripts/shared_colors.shader
@@ -6,7 +6,7 @@ textures/shared_colors/black
 	surfaceparm nomarks
 
 	{
-		map textures/shared_colors_src/black_d
+		map $black
 	}
 }
 
@@ -19,7 +19,7 @@ textures/shared_colors/black_nonsolid
 	surfaceparm nonsolid
 
 	{
-		map textures/shared_colors_src/black_d
+		map $black
 	}
 }
 
@@ -56,7 +56,7 @@ textures/shared_colors/white
 	surfaceparm nomarks
 
 	{
-		map textures/shared_colors_src/white_d
+		map $white
 	}
 }
 
@@ -69,7 +69,7 @@ textures/shared_colors/white_nonsolid
 	surfaceparm nonsolid
 
 	{
-		map textures/shared_colors_src/white_d
+		map $white
 	}
 }
 
@@ -81,7 +81,7 @@ textures/shared_colors/red
 	surfaceparm nomarks
 
 	{
-		map textures/shared_colors_src/red_d
+		map $red
 	}
 }
 
@@ -94,7 +94,7 @@ textures/shared_colors/red_nonsolid
 	surfaceparm nonsolid
 
 	{
-		map textures/shared_colors_src/red_d
+		map $red
 	}
 }
 
@@ -181,7 +181,7 @@ textures/shared_colors/green
 	surfaceparm nomarks
 
 	{
-		map textures/shared_colors_src/green_d
+		map $green
 	}
 }
 
@@ -194,7 +194,7 @@ textures/shared_colors/green_nonsolid
 	surfaceparm nonsolid
 
 	{
-		map textures/shared_colors_src/green_d
+		map $green
 	}
 }
 
@@ -281,7 +281,7 @@ textures/shared_colors/blue
 	surfaceparm nomarks
 
 	{
-		map textures/shared_colors_src/blue_d
+		map $blue
 	}
 }
 
@@ -294,7 +294,7 @@ textures/shared_colors/blue_nonsolid
 	surfaceparm nonsolid
 
 	{
-		map textures/shared_colors_src/blue_d
+		map $blue
 	}
 }
 
@@ -373,8 +373,8 @@ textures/shared_colors/rose_nonsolid
 	}
 }
 
-// The fully transparent texture with transparent editor image
-// should not be listed and selectable in editor. It can be used
+// The transparent texture that is also transparent in editor too.
+// It should not be listed and selectable in editor. It can be used
 // on model surfaces to hide them.
 gfx/shared_colors/transparent
 {
@@ -384,11 +384,6 @@ gfx/shared_colors/transparent
 	surfaceparm nolightmap
 	surfaceparm nomarks
 	surfaceparm trans
-
-	{
-		map textures/shared_colors_src/transparent_d
-		blendFunc blend
-	}
 }
 
 gfx/shared_colors/transparent_nonsolid
@@ -400,9 +395,4 @@ gfx/shared_colors/transparent_nonsolid
 	surfaceparm nomarks
 	surfaceparm nonsolid
 	surfaceparm trans
-
-	{
-		map textures/shared_colors_src/transparent_d
-		blendFunc blend
-	}
 }

--- a/scripts/shared_colors.shader
+++ b/scripts/shared_colors.shader
@@ -6,7 +6,7 @@ textures/shared_colors/black
 	surfaceparm nomarks
 
 	{
-		diffuseMap textures/shared_colors_src/black_d
+		map textures/shared_colors_src/black_d
 	}
 }
 
@@ -19,7 +19,7 @@ textures/shared_colors/black_nonsolid
 	surfaceparm nonsolid
 
 	{
-		diffuseMap textures/shared_colors_src/black_d
+		map textures/shared_colors_src/black_d
 	}
 }
 
@@ -31,7 +31,7 @@ textures/shared_colors/gray
 	surfaceparm nomarks
 
 	{
-		diffuseMap textures/shared_colors_src/gray_d
+		map textures/shared_colors_src/gray_d
 	}
 }
 
@@ -44,7 +44,7 @@ textures/shared_colors/gray_nonsolid
 	surfaceparm nonsolid
 
 	{
-		diffuseMap textures/shared_colors_src/gray_d
+		map textures/shared_colors_src/gray_d
 	}
 }
 
@@ -56,7 +56,7 @@ textures/shared_colors/white
 	surfaceparm nomarks
 
 	{
-		diffuseMap textures/shared_colors_src/white_d
+		map textures/shared_colors_src/white_d
 	}
 }
 
@@ -69,7 +69,7 @@ textures/shared_colors/white_nonsolid
 	surfaceparm nonsolid
 
 	{
-		diffuseMap textures/shared_colors_src/white_d
+		map textures/shared_colors_src/white_d
 	}
 }
 
@@ -81,7 +81,7 @@ textures/shared_colors/red
 	surfaceparm nomarks
 
 	{
-		diffuseMap textures/shared_colors_src/red_d
+		map textures/shared_colors_src/red_d
 	}
 }
 
@@ -94,7 +94,7 @@ textures/shared_colors/red_nonsolid
 	surfaceparm nonsolid
 
 	{
-		diffuseMap textures/shared_colors_src/red_d
+		map textures/shared_colors_src/red_d
 	}
 }
 
@@ -106,7 +106,7 @@ textures/shared_colors/orange
 	surfaceparm nomarks
 
 	{
-		diffuseMap textures/shared_colors_src/orange_d
+		map textures/shared_colors_src/orange_d
 	}
 }
 
@@ -119,7 +119,7 @@ textures/shared_colors/orange_nonsolid
 	surfaceparm nonsolid
 
 	{
-		diffuseMap textures/shared_colors_src/orange_d
+		map textures/shared_colors_src/orange_d
 	}
 }
 
@@ -131,7 +131,7 @@ textures/shared_colors/yellow
 	surfaceparm nomarks
 
 	{
-		diffuseMap textures/shared_colors_src/yellow_d
+		map textures/shared_colors_src/yellow_d
 	}
 }
 
@@ -144,7 +144,7 @@ textures/shared_colors/yellow_nonsolid
 	surfaceparm nonsolid
 
 	{
-		diffuseMap textures/shared_colors_src/yellow_d
+		map textures/shared_colors_src/yellow_d
 	}
 }
 
@@ -156,7 +156,7 @@ textures/shared_colors/chartreuse
 	surfaceparm nomarks
 
 	{
-		diffuseMap textures/shared_colors_src/chartreuse_d
+		map textures/shared_colors_src/chartreuse_d
 	}
 }
 
@@ -169,7 +169,7 @@ textures/shared_colors/chartreuse_nonsolid
 	surfaceparm nonsolid
 
 	{
-		diffuseMap textures/shared_colors_src/chartreuse_d
+		map textures/shared_colors_src/chartreuse_d
 	}
 }
 
@@ -181,7 +181,7 @@ textures/shared_colors/green
 	surfaceparm nomarks
 
 	{
-		diffuseMap textures/shared_colors_src/green_d
+		map textures/shared_colors_src/green_d
 	}
 }
 
@@ -194,7 +194,7 @@ textures/shared_colors/green_nonsolid
 	surfaceparm nonsolid
 
 	{
-		diffuseMap textures/shared_colors_src/green_d
+		map textures/shared_colors_src/green_d
 	}
 }
 
@@ -206,7 +206,7 @@ textures/shared_colors/spring
 	surfaceparm nomarks
 
 	{
-		diffuseMap textures/shared_colors_src/spring_d
+		map textures/shared_colors_src/spring_d
 	}
 }
 
@@ -219,7 +219,7 @@ textures/shared_colors/spring_nonsolid
 	surfaceparm nonsolid
 
 	{
-		diffuseMap textures/shared_colors_src/spring_d
+		map textures/shared_colors_src/spring_d
 	}
 }
 
@@ -231,7 +231,7 @@ textures/shared_colors/cyan
 	surfaceparm nomarks
 
 	{
-		diffuseMap textures/shared_colors_src/cyan_d
+		map textures/shared_colors_src/cyan_d
 	}
 }
 
@@ -244,7 +244,7 @@ textures/shared_colors/cyan_nonsolid
 	surfaceparm nonsolid
 
 	{
-		diffuseMap textures/shared_colors_src/cyan_d
+		map textures/shared_colors_src/cyan_d
 	}
 }
 
@@ -256,7 +256,7 @@ textures/shared_colors/azure
 	surfaceparm nomarks
 
 	{
-		diffuseMap textures/shared_colors_src/azure_d
+		map textures/shared_colors_src/azure_d
 	}
 }
 
@@ -269,7 +269,7 @@ textures/shared_colors/azure_nonsolid
 	surfaceparm nonsolid
 
 	{
-		diffuseMap textures/shared_colors_src/azure_d
+		map textures/shared_colors_src/azure_d
 	}
 }
 
@@ -281,7 +281,7 @@ textures/shared_colors/blue
 	surfaceparm nomarks
 
 	{
-		diffuseMap textures/shared_colors_src/blue_d
+		map textures/shared_colors_src/blue_d
 	}
 }
 
@@ -294,7 +294,7 @@ textures/shared_colors/blue_nonsolid
 	surfaceparm nonsolid
 
 	{
-		diffuseMap textures/shared_colors_src/blue_d
+		map textures/shared_colors_src/blue_d
 	}
 }
 
@@ -306,7 +306,7 @@ textures/shared_colors/violet
 	surfaceparm nomarks
 
 	{
-		diffuseMap textures/shared_colors_src/violet_d
+		map textures/shared_colors_src/violet_d
 	}
 }
 
@@ -319,7 +319,7 @@ textures/shared_colors/violet_nonsolid
 	surfaceparm nonsolid
 
 	{
-		diffuseMap textures/shared_colors_src/violet_d
+		map textures/shared_colors_src/violet_d
 	}
 }
 
@@ -331,7 +331,7 @@ textures/shared_colors/magenta
 	surfaceparm nomarks
 
 	{
-		diffuseMap textures/shared_colors_src/magenta_d
+		map textures/shared_colors_src/magenta_d
 	}
 }
 
@@ -344,7 +344,7 @@ textures/shared_colors/magenta_nonsolid
 	surfaceparm nonsolid
 
 	{
-		diffuseMap textures/shared_colors_src/magenta_d
+		map textures/shared_colors_src/magenta_d
 	}
 }
 
@@ -356,7 +356,7 @@ textures/shared_colors/rose
 	surfaceparm nomarks
 
 	{
-		diffuseMap textures/shared_colors_src/rose_d
+		map textures/shared_colors_src/rose_d
 	}
 }
 
@@ -369,7 +369,7 @@ textures/shared_colors/rose_nonsolid
 	surfaceparm nonsolid
 
 	{
-		diffuseMap textures/shared_colors_src/rose_d
+		map textures/shared_colors_src/rose_d
 	}
 }
 
@@ -386,7 +386,7 @@ gfx/shared_colors/transparent
 	surfaceparm trans
 
 	{
-		diffuseMap textures/shared_colors_src/transparent_d
+		map textures/shared_colors_src/transparent_d
 		blendFunc blend
 	}
 }
@@ -402,7 +402,7 @@ gfx/shared_colors/transparent_nonsolid
 	surfaceparm trans
 
 	{
-		diffuseMap textures/shared_colors_src/transparent_d
+		map textures/shared_colors_src/transparent_d
 		blendFunc blend
 	}
 }


### PR DESCRIPTION
This doesn't fix any bug neither bring new features, it just does things in a better way.

- urcheon: properly copy the transparent tga
  The transparent image is used in editor. An 1×1 TGA is the smallest image format.
- materials: use `map` instead of `diffuseMap`, there is no lightmap to use
- materials: use engine builtin images
- materials: rewrite portal and mirror using a builtin image

It requires:

- https://github.com/DaemonEngine/Daemon/pull/1806

Even though it is not required to merge that engine PR on `for-0.56.0/sync`, we should not distribute this change in a point release as older engines would not render those materials properly.